### PR TITLE
[LIVY-732][SERVER] A common zookeeper wrapper utility

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -107,6 +107,8 @@
 # Must set livy.server.recovery.state-store and livy.server.recovery.state-store.url to
 # configure the state store.
 # livy.server.recovery.mode = off
+# Zookeeper address used for HA and state store. e.g. host1:port1, host2:port2
+# livy.server.zookeeper.url =
 
 # Where Livy should store state to for recovery. Possible values:
 # <empty>: Default. State store disabled.
@@ -116,7 +118,7 @@
 
 # For filesystem state store, the path of the state store directory. Please don't use a filesystem
 # that doesn't support atomic rename (e.g. S3). e.g. file:///tmp/livy or hdfs:///.
-# For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
+# For zookeeper, please set livy.server.zookeeper.url
 # livy.server.recovery.state-store.url =
 
 # If Livy can't find the yarn app within this time, consider it lost.

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -121,6 +121,19 @@
 # For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
 # livy.server.recovery.state-store.url =
 
+# The policy of curator connecting to zookeeper.
+# For example, m, n means retry m times and the interval of retry is n milliseconds.
+# Please use the new config: livy.server.zk.retry-policy.
+# Keep this config is just for back-compatibility
+# livy.server.recovery.zk-state-store.retry-policy = 5,100
+
+# The policy of curator connecting to zookeeper.
+# For example, m, n means retry m times and the interval of retry is n milliseconds
+# livy.server.zk.retry-policy = 5,100
+
+# The dir in zk to store the data about session.
+# livy.server.recovery.zk-state-store.key-prefix = livy
+
 # If Livy can't find the yarn app within this time, consider it lost.
 # livy.server.yarn.app-lookup-timeout = 120s
 # When the cluster is busy, we may fail to launch yarn app in app-lookup-timeout, then it would

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -134,7 +134,7 @@
 
 # The policy of curator connecting to zookeeper.
 # For example, m, n means retry m times and the interval of retry is n milliseconds
-# livy.server.zk.retry-policy = 5,100
+# livy.server.zk.retry-policy =
 
 # The dir in zk to store the data about session.
 # livy.server.recovery.zk-state-store.key-prefix = livy

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -118,7 +118,7 @@
 
 # For filesystem state store, the path of the state store directory. Please don't use a filesystem
 # that doesn't support atomic rename (e.g. S3). e.g. file:///tmp/livy or hdfs:///.
-# For zookeeper, please set livy.server.zookeeper.url
+# For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
 # livy.server.recovery.state-store.url =
 
 # If Livy can't find the yarn app within this time, consider it lost.

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -119,12 +119,17 @@
 # For filesystem state store, the path of the state store directory. Please don't use a filesystem
 # that doesn't support atomic rename (e.g. S3). e.g. file:///tmp/livy or hdfs:///.
 # For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
+# If livy.server.recovery.state-store is zookeeper, this config is for back-compatibility,
+# so if both this config and livy.server.zookeeper.url exist,
+# livy uses livy.server.zookeeper.url first.
 # livy.server.recovery.state-store.url =
 
 # The policy of curator connecting to zookeeper.
 # For example, m, n means retry m times and the interval of retry is n milliseconds.
 # Please use the new config: livy.server.zk.retry-policy.
-# Keep this config is just for back-compatibility
+# Keep this config for back-compatibility.
+# If both this config and livy.server.zk.retry-policy exist,
+# livy uses livy.server.zk.retry-policy first.
 # livy.server.recovery.zk-state-store.retry-policy = 5,100
 
 # The policy of curator connecting to zookeeper.

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -185,6 +185,10 @@ object LivyConf {
    * configure the state store.
    */
   val RECOVERY_MODE = Entry("livy.server.recovery.mode", "off")
+
+  // Zookeeper address used for HA and state store. e.g. host1:port1, host2:port2
+  val ZOOKEEPER_URL = Entry("livy.server.zookeeper.url", "")
+
   /**
    * Where Livy should store state to for recovery. Possible values:
    * <empty>: Default. State store disabled.
@@ -195,7 +199,7 @@ object LivyConf {
   /**
    * For filesystem state store, the path of the state store directory. Please don't use a
    * filesystem that doesn't support atomic rename (e.g. S3). e.g. file:///tmp/livy or hdfs:///.
-   * For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
+   * For zookeeper, please set livy.server.zookeeper.url
    */
   val RECOVERY_STATE_STORE_URL = Entry("livy.server.recovery.state-store.url", "")
 

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -187,7 +187,7 @@ object LivyConf {
   val RECOVERY_MODE = Entry("livy.server.recovery.mode", "off")
 
   // Zookeeper address used for HA and state store. e.g. host1:port1, host2:port2
-  val ZOOKEEPER_URL = Entry("livy.server.zookeeper.url", "")
+  val ZOOKEEPER_URL = Entry("livy.server.zookeeper.url", null)
 
   /**
    * Where Livy should store state to for recovery. Possible values:
@@ -204,7 +204,7 @@ object LivyConf {
    * so if both this config and livy.server.zookeeper.url exist,
    * livy uses livy.server.zookeeper.url first.
    */
-  val RECOVERY_STATE_STORE_URL = Entry("livy.server.recovery.state-store.url", "")
+  val RECOVERY_STATE_STORE_URL = Entry("livy.server.recovery.state-store.url", null)
 
   /**
     * The policy of curator connecting to zookeeper.
@@ -221,7 +221,7 @@ object LivyConf {
     * The policy of curator connecting to zookeeper.
     * For example, m, n means retry m times and the interval of retry is n milliseconds
    */
-  val ZK_RETRY_POLICY = Entry("livy.server.zk.retry-policy", "5,100")
+  val ZK_RETRY_POLICY = Entry("livy.server.zk.retry-policy", null)
 
   // The dir in zookeeper to store the data about session.
   val RECOVERY_ZK_STATE_STORE_KEY_PREFIX =

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -200,6 +200,9 @@ object LivyConf {
    * For filesystem state store, the path of the state store directory. Please don't use a
    * filesystem that doesn't support atomic rename (e.g. S3). e.g. file:///tmp/livy or hdfs:///.
    * For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
+   * If livy.server.recovery.state-store is zookeeper, this config is for back-compatibility,
+   * so if both this config and livy.server.zookeeper.url exist,
+   * livy uses livy.server.zookeeper.url first.
    */
   val RECOVERY_STATE_STORE_URL = Entry("livy.server.recovery.state-store.url", "")
 
@@ -207,7 +210,9 @@ object LivyConf {
     * The policy of curator connecting to zookeeper.
     * For example, m, n means retry m times and the interval of retry is n milliseconds.
     * Please use the new config: livy.server.zk.retry-policy.
-    * Keep this config is just for  back-compatibility.
+    * Keep this config for back-compatibility.
+    * If both this config and livy.server.zk.retry-policy exist,
+    * livy uses livy.server.zk.retry-policy first.
     */
   val RECOVERY_ZK_STATE_STORE_RETRY_POLICY =
     Entry("livy.server.recovery.zk-state-store.retry-policy", "5,100")

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -203,6 +203,25 @@ object LivyConf {
    */
   val RECOVERY_STATE_STORE_URL = Entry("livy.server.recovery.state-store.url", "")
 
+  /**
+    * The policy of curator connecting to zookeeper.
+    * For example, m, n means retry m times and the interval of retry is n milliseconds.
+    * Please use the new config: livy.server.zk.retry-policy.
+    * Keep this config is just for  back-compatibility.
+    */
+  val RECOVERY_ZK_STATE_STORE_RETRY_POLICY =
+    Entry("livy.server.recovery.zk-state-store.retry-policy", "5,100")
+
+  /**
+    * The policy of curator connecting to zookeeper.
+    * For example, m, n means retry m times and the interval of retry is n milliseconds
+   */
+  val ZK_RETRY_POLICY = Entry("livy.server.zk.retry-policy", "5,100")
+
+  // The dir in zookeeper to store the data about session.
+  val RECOVERY_ZK_STATE_STORE_KEY_PREFIX =
+    Entry("livy.server.recovery.zk-state-store.key-prefix", "livy")
+
   // Livy will cache the max no of logs specified. 0 means don't cache the logs.
   val SPARK_LOGS_SIZE = Entry("livy.cache-log.size", 200)
 

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -199,7 +199,7 @@ object LivyConf {
   /**
    * For filesystem state store, the path of the state store directory. Please don't use a
    * filesystem that doesn't support atomic rename (e.g. S3). e.g. file:///tmp/livy or hdfs:///.
-   * For zookeeper, please set livy.server.zookeeper.url
+   * For zookeeper, the address to the Zookeeper servers. e.g. host1:port1,host2:port2
    */
   val RECOVERY_STATE_STORE_URL = Entry("livy.server.recovery.state-store.url", "")
 

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -150,7 +150,7 @@ class LivyServer extends Logging {
 
     if (livyConf.get(LivyConf.RECOVERY_STATE_STORE) == "zookeeper") {
       zkManager = Some(new ZooKeeperManager(livyConf))
-      zkManager.foreach(_.startCuratorClient())
+      zkManager.foreach(_.start())
     }
 
     StateStore.init(livyConf, zkManager)
@@ -330,7 +330,7 @@ class LivyServer extends Logging {
     Runtime.getRuntime().addShutdownHook(new Thread("Livy Server Shutdown") {
       override def run(): Unit = {
         info("Shutting down Livy server.")
-        zkManager.foreach(_.stopCuratorClient())
+        zkManager.foreach(_.stop())
         server.stop()
         _thriftServerFactory.foreach(_.stop())
       }

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -39,7 +39,7 @@ import org.apache.livy._
 import org.apache.livy.server.auth.LdapAuthenticationHandlerImpl
 import org.apache.livy.server.batch.BatchSessionServlet
 import org.apache.livy.server.interactive.InteractiveSessionServlet
-import org.apache.livy.server.recovery.{SessionStore, StateStore}
+import org.apache.livy.server.recovery.{SessionStore, StateStore, ZooKeeperManager}
 import org.apache.livy.server.ui.UIServlet
 import org.apache.livy.sessions.{BatchSessionManager, InteractiveSessionManager}
 import org.apache.livy.sessions.SessionManager.SESSION_RECOVERY_MODE_OFF
@@ -144,6 +144,10 @@ class LivyServer extends Logging {
     if (livyConf.isRunningOnYarn()) {
       SparkYarnApp.init(livyConf)
       Future { SparkYarnApp.yarnClient }
+    }
+
+    if (livyConf.get(LivyConf.RECOVERY_STATE_STORE) == "zookeeper") {
+      ZooKeeperManager(livyConf)
     }
 
     StateStore.init(livyConf)

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -150,6 +150,7 @@ class LivyServer extends Logging {
 
     if (livyConf.get(LivyConf.RECOVERY_STATE_STORE) == "zookeeper") {
       zkManager = Some(new ZooKeeperManager(livyConf))
+      zkManager.foreach(_.startCuratorClient())
     }
 
     StateStore.init(livyConf, zkManager)
@@ -329,6 +330,7 @@ class LivyServer extends Logging {
     Runtime.getRuntime().addShutdownHook(new Thread("Livy Server Shutdown") {
       override def run(): Unit = {
         info("Shutting down Livy server.")
+        zkManager.foreach(_.stopCuratorClient())
         server.stop()
         _thriftServerFactory.foreach(_.stop())
       }

--- a/server/src/main/scala/org/apache/livy/server/LivyServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/LivyServer.scala
@@ -60,6 +60,8 @@ class LivyServer extends Logging {
   private var accessManager: AccessManager = _
   private var _thriftServerFactory: Option[ThriftServerFactory] = None
 
+  private var zkManager: Option[ZooKeeperManager] = None
+
   private var ugi: UserGroupInformation = _
 
   def start(): Unit = {
@@ -147,10 +149,10 @@ class LivyServer extends Logging {
     }
 
     if (livyConf.get(LivyConf.RECOVERY_STATE_STORE) == "zookeeper") {
-      ZooKeeperManager(livyConf)
+      zkManager = Some(new ZooKeeperManager(livyConf))
     }
 
-    StateStore.init(livyConf)
+    StateStore.init(livyConf, zkManager)
     val sessionStore = new SessionStore(livyConf)
     val batchSessionManager = new BatchSessionManager(livyConf, sessionStore)
     val interactiveSessionManager = new InteractiveSessionManager(livyConf, sessionStore)

--- a/server/src/main/scala/org/apache/livy/server/recovery/FileSystemStateStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/FileSystemStateStore.scala
@@ -44,7 +44,8 @@ class FileSystemStateStore(
 
   private val fsUri = {
     val fsPath = livyConf.get(LivyConf.RECOVERY_STATE_STORE_URL)
-    require(fsPath != null, s"Please config ${LivyConf.RECOVERY_STATE_STORE_URL.key}.")
+    require(fsPath != null && !fsPath.isEmpty,
+      s"Please config ${LivyConf.RECOVERY_STATE_STORE_URL.key}.")
     new URI(fsPath)
   }
 

--- a/server/src/main/scala/org/apache/livy/server/recovery/FileSystemStateStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/FileSystemStateStore.scala
@@ -44,7 +44,7 @@ class FileSystemStateStore(
 
   private val fsUri = {
     val fsPath = livyConf.get(LivyConf.RECOVERY_STATE_STORE_URL)
-    require(!fsPath.isEmpty, s"Please config ${LivyConf.RECOVERY_STATE_STORE_URL.key}.")
+    require(fsPath != null, s"Please config ${LivyConf.RECOVERY_STATE_STORE_URL.key}.")
     new URI(fsPath)
   }
 

--- a/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.server.recovery
+
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+
+import org.apache.curator.framework.api.UnhandledErrorListener
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.CuratorFrameworkFactory
+import org.apache.curator.retry.RetryNTimes
+import org.apache.zookeeper.KeeperException.NoNodeException
+
+import org.apache.livy.LivyConf
+import org.apache.livy.LivyConf.Entry
+import org.apache.livy.Logging
+
+object ZooKeeperManager {
+  val ZK_KEY_PREFIX_CONF = Entry("livy.server.recovery.zk-state-store.key-prefix", "livy")
+  val ZK_RETRY_CONF = Entry("livy.server.recovery.zk-state-store.retry-policy", "5,100")
+  val DUPLICATE_CREATE_EXCEPTION = "ZooKeeperManager single instance has already been created"
+
+  @volatile private var zkManager: ZooKeeperManager = _
+
+  def apply(livyConf: LivyConf,
+    mockCuratorClient: Option[CuratorFramework] = None):
+  ZooKeeperManager = synchronized {
+    if (zkManager == null) {
+      zkManager = new ZooKeeperManager(livyConf, mockCuratorClient)
+    } else {
+      throw new IllegalAccessException(DUPLICATE_CREATE_EXCEPTION)
+    }
+
+    zkManager
+  }
+
+  def get(): ZooKeeperManager = zkManager
+
+  // for test
+  private[recovery] def reset(): Unit = {
+    zkManager = null
+  }
+}
+
+class ZooKeeperManager private(
+    livyConf: LivyConf,
+    mockCuratorClient: Option[CuratorFramework] = None)
+  extends JsonMapper with Logging {
+
+  import ZooKeeperManager._
+
+  private val zkAddress = livyConf.get(LivyConf.ZOOKEEPER_URL)
+  require(!zkAddress.isEmpty, s"Please config ${LivyConf.RECOVERY_STATE_STORE_URL.key}.")
+  private val zkKeyPrefix = livyConf.get(ZK_KEY_PREFIX_CONF)
+  private val retryValue = livyConf.get(ZK_RETRY_CONF)
+  // a regex to match patterns like "m, n" where m and n both are integer values
+  private val retryPattern = """\s*(\d+)\s*,\s*(\d+)\s*""".r
+  private[recovery] val retryPolicy = retryValue match {
+    case retryPattern(n, sleepMs) => new RetryNTimes(n.toInt, sleepMs.toInt)
+    case _ => throw new IllegalArgumentException(
+      s"$ZK_KEY_PREFIX_CONF contains bad value: $retryValue. " +
+        "Correct format is <max retry count>,<sleep ms between retry>. e.g. 5,100")
+  }
+
+  private val curatorClient = mockCuratorClient.getOrElse {
+    CuratorFrameworkFactory.newClient(zkAddress, retryPolicy)
+  }
+
+  Runtime.getRuntime.addShutdownHook(new Thread(new Runnable {
+    override def run(): Unit = {
+      curatorClient.close()
+    }
+  }))
+
+  curatorClient.getUnhandledErrorListenable().addListener(new UnhandledErrorListener {
+    def unhandledError(message: String, e: Throwable): Unit = {
+      error(s"Fatal Zookeeper error. Shutting down Livy server.")
+      System.exit(1)
+    }
+  })
+  curatorClient.start()
+  // TODO Make sure ZK path has proper secure permissions so that other users cannot read its
+  // contents.
+
+  def set(key: String, value: Object): Unit = {
+    val prefixedKey = prefixKey(key)
+    val data = serializeToBytes(value)
+    if (curatorClient.checkExists().forPath(prefixedKey) == null) {
+      curatorClient.create().creatingParentsIfNeeded().forPath(prefixedKey, data)
+    } else {
+      curatorClient.setData().forPath(prefixedKey, data)
+    }
+  }
+
+  def get[T: ClassTag](key: String): Option[T] = {
+    val prefixedKey = prefixKey(key)
+    if (curatorClient.checkExists().forPath(prefixedKey) == null) {
+      None
+    } else {
+      Option(deserialize[T](curatorClient.getData().forPath(prefixedKey)))
+    }
+  }
+
+  def getChildren(key: String): Seq[String] = {
+    val prefixedKey = prefixKey(key)
+    if (curatorClient.checkExists().forPath(prefixedKey) == null) {
+      Seq.empty[String]
+    } else {
+      curatorClient.getChildren.forPath(prefixedKey).asScala
+    }
+  }
+
+  def remove(key: String): Unit = {
+    try {
+      curatorClient.delete().guaranteed().forPath(prefixKey(key))
+    } catch {
+      case _: NoNodeException => warn(s"Fail to remove non-existed zookeeper node: ${key}")
+    }
+  }
+
+  private def prefixKey(key: String) = s"/$zkKeyPrefix/$key"
+}

--- a/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
@@ -65,19 +65,21 @@ class ZooKeeperManager(
     CuratorFrameworkFactory.newClient(zkAddress, retryPolicy)
   }
 
-  Runtime.getRuntime.addShutdownHook(new Thread(new Runnable {
-    override def run(): Unit = {
-      curatorClient.close()
-    }
-  }))
-
   curatorClient.getUnhandledErrorListenable().addListener(new UnhandledErrorListener {
     def unhandledError(message: String, e: Throwable): Unit = {
       error(s"Fatal Zookeeper error. Shutting down Livy server.")
       System.exit(1)
     }
   })
-  curatorClient.start()
+
+  def startCuratorClient(): Unit = {
+    curatorClient.start()
+  }
+
+  def stopCuratorClient(): Unit = {
+    curatorClient.close()
+  }
+
   // TODO Make sure ZK path has proper secure permissions so that other users cannot read its
   // contents.
 

--- a/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
@@ -39,24 +39,24 @@ class ZooKeeperManager(
   }
 
   private val zkAddress = {
-    val zkUrl = livyConf.get(LivyConf.RECOVERY_STATE_STORE_URL)
+    val zkUrl = livyConf.get(LivyConf.ZOOKEEPER_URL)
     if (!zkUrl.isEmpty) {
-      // for back-compatibility
       zkUrl
     } else {
-      livyConf.get(LivyConf.ZOOKEEPER_URL)
+      // for back-compatibility
+      livyConf.get(LivyConf.RECOVERY_STATE_STORE_URL)
     }
   }
 
   require(!zkAddress.isEmpty, s"Please config ${LivyConf.ZOOKEEPER_URL.key}.")
 
   private val retryValue = {
-    val retryConf = livyConf.get(LivyConf.RECOVERY_ZK_STATE_STORE_RETRY_POLICY)
+    val retryConf = livyConf.get(LivyConf.ZK_RETRY_POLICY)
     if (!retryConf.isEmpty) {
-      // for back-compatibility
       retryConf
     } else {
-      livyConf.get(LivyConf.ZK_RETRY_POLICY)
+      // for back-compatibility
+      livyConf.get(LivyConf.RECOVERY_ZK_STATE_STORE_RETRY_POLICY)
     }
   }
 

--- a/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
@@ -38,27 +38,19 @@ class ZooKeeperManager(
     this(livyConf, None)
   }
 
-  private val zkAddress = {
-    val zkUrl = livyConf.get(LivyConf.ZOOKEEPER_URL)
-    if (!zkUrl.isEmpty) {
-      zkUrl
-    } else {
-      // for back-compatibility
-      livyConf.get(LivyConf.RECOVERY_STATE_STORE_URL)
-    }
-  }
+  private val zkAddress = Option(livyConf.get(LivyConf.ZOOKEEPER_URL)).getOrElse {
+    // for back-compatibility
+    val url = livyConf.get(LivyConf.RECOVERY_STATE_STORE_URL)
+    require(url != null, s"Please config ${LivyConf.ZOOKEEPER_URL.key}.")
+    url
+  }.trim
 
-  require(!zkAddress.isEmpty, s"Please config ${LivyConf.ZOOKEEPER_URL.key}.")
-
-  private val retryValue = {
-    val retryConf = livyConf.get(LivyConf.ZK_RETRY_POLICY)
-    if (!retryConf.isEmpty) {
-      retryConf
-    } else {
-      // for back-compatibility
-      livyConf.get(LivyConf.RECOVERY_ZK_STATE_STORE_RETRY_POLICY)
-    }
-  }
+  private val retryValue = Option(livyConf.get(LivyConf.ZK_RETRY_POLICY)).getOrElse {
+    // for back-compatibility
+    val policy = livyConf.get(LivyConf.RECOVERY_ZK_STATE_STORE_RETRY_POLICY)
+    require(policy != null, s"Please config ${LivyConf.ZK_RETRY_POLICY.key}.")
+    policy
+  }.trim
 
   // a regex to match patterns like "m, n" where m and n both are integer values
   private val retryPattern = """\s*(\d+)\s*,\s*(\d+)\s*""".r

--- a/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
@@ -28,6 +28,7 @@ import org.apache.zookeeper.KeeperException.NoNodeException
 
 import org.apache.livy.LivyConf
 import org.apache.livy.Logging
+import org.apache.livy.utils.LivyUncaughtException
 
 class ZooKeeperManager(
     livyConf: LivyConf,
@@ -68,6 +69,7 @@ class ZooKeeperManager(
   curatorClient.getUnhandledErrorListenable().addListener(new UnhandledErrorListener {
     def unhandledError(message: String, e: Throwable): Unit = {
       error(s"Fatal Zookeeper error: ${message}.", e)
+      throw new LivyUncaughtException(e.getMessage)
     }
   })
 
@@ -81,7 +83,6 @@ class ZooKeeperManager(
 
   // TODO Make sure ZK path has proper secure permissions so that other users cannot read its
   // contents.
-
   def set(key: String, value: Object): Unit = {
     val data = serializeToBytes(value)
     if (curatorClient.checkExists().forPath(key) == null) {
@@ -114,5 +115,4 @@ class ZooKeeperManager(
       case _: NoNodeException => warn(s"Fail to remove non-existed zookeeper node: ${key}")
     }
   }
-
 }

--- a/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperStateStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperStateStore.scala
@@ -16,103 +16,26 @@
  */
 package org.apache.livy.server.recovery
 
-import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
-import scala.util.Try
-
-import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
-import org.apache.curator.framework.api.UnhandledErrorListener
-import org.apache.curator.retry.RetryNTimes
-import org.apache.zookeeper.KeeperException.NoNodeException
 
 import org.apache.livy.{LivyConf, Logging}
-import org.apache.livy.LivyConf.Entry
 
-object ZooKeeperStateStore {
-  val ZK_KEY_PREFIX_CONF = Entry("livy.server.recovery.zk-state-store.key-prefix", "livy")
-  val ZK_RETRY_CONF = Entry("livy.server.recovery.zk-state-store.retry-policy", "5,100")
-}
-
-class ZooKeeperStateStore(
-    livyConf: LivyConf,
-    mockCuratorClient: Option[CuratorFramework] = None) // For testing
-  extends StateStore(livyConf) with Logging {
-
-  import ZooKeeperStateStore._
-
-  // Constructor defined for StateStore factory to new this class using reflection.
-  def this(livyConf: LivyConf) {
-    this(livyConf, None)
-  }
-
-  private val zkAddress = livyConf.get(LivyConf.RECOVERY_STATE_STORE_URL)
-  require(!zkAddress.isEmpty, s"Please config ${LivyConf.RECOVERY_STATE_STORE_URL.key}.")
-  private val zkKeyPrefix = livyConf.get(ZK_KEY_PREFIX_CONF)
-  private val retryValue = livyConf.get(ZK_RETRY_CONF)
-  // a regex to match patterns like "m, n" where m and n both are integer values
-  private val retryPattern = """\s*(\d+)\s*,\s*(\d+)\s*""".r
-  private[recovery] val retryPolicy = retryValue match {
-    case retryPattern(n, sleepMs) => new RetryNTimes(n.toInt, sleepMs.toInt)
-    case _ => throw new IllegalArgumentException(
-      s"$ZK_KEY_PREFIX_CONF contains bad value: $retryValue. " +
-        "Correct format is <max retry count>,<sleep ms between retry>. e.g. 5,100")
-  }
-
-  private val curatorClient = mockCuratorClient.getOrElse {
-    CuratorFrameworkFactory.newClient(zkAddress, retryPolicy)
-  }
-
-  Runtime.getRuntime.addShutdownHook(new Thread(new Runnable {
-    override def run(): Unit = {
-      curatorClient.close()
-    }
-  }))
-
-  curatorClient.getUnhandledErrorListenable().addListener(new UnhandledErrorListener {
-    def unhandledError(message: String, e: Throwable): Unit = {
-      error(s"Fatal Zookeeper error. Shutting down Livy server.")
-      System.exit(1)
-    }
-  })
-  curatorClient.start()
-  // TODO Make sure ZK path has proper secure permissions so that other users cannot read its
-  // contents.
+class ZooKeeperStateStore(livyConf: LivyConf) extends StateStore(livyConf) {
+  require(ZooKeeperManager.get != null)
 
   override def set(key: String, value: Object): Unit = {
-    val prefixedKey = prefixKey(key)
-    val data = serializeToBytes(value)
-    if (curatorClient.checkExists().forPath(prefixedKey) == null) {
-      curatorClient.create().creatingParentsIfNeeded().forPath(prefixedKey, data)
-    } else {
-      curatorClient.setData().forPath(prefixedKey, data)
-    }
+    ZooKeeperManager.get.set(key, value)
   }
 
   override def get[T: ClassTag](key: String): Option[T] = {
-    val prefixedKey = prefixKey(key)
-    if (curatorClient.checkExists().forPath(prefixedKey) == null) {
-      None
-    } else {
-      Option(deserialize[T](curatorClient.getData().forPath(prefixedKey)))
-    }
+    ZooKeeperManager.get.get(key)
   }
 
   override def getChildren(key: String): Seq[String] = {
-    val prefixedKey = prefixKey(key)
-    if (curatorClient.checkExists().forPath(prefixedKey) == null) {
-      Seq.empty[String]
-    } else {
-      curatorClient.getChildren.forPath(prefixedKey).asScala
-    }
+    ZooKeeperManager.get.getChildren(key)
   }
 
   override def remove(key: String): Unit = {
-    try {
-      curatorClient.delete().guaranteed().forPath(prefixKey(key))
-    } catch {
-      case _: NoNodeException => warn(s"Fail to remove non-existed zookeeper node: ${key}")
-    }
+    ZooKeeperManager.get.remove(key)
   }
-
-  private def prefixKey(key: String) = s"/$zkKeyPrefix/$key"
 }

--- a/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperStateStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperStateStore.scala
@@ -19,15 +19,13 @@ package org.apache.livy.server.recovery
 import scala.reflect.ClassTag
 
 import org.apache.livy.LivyConf
-import org.apache.livy.LivyConf.Entry
 
 class ZooKeeperStateStore(
     livyConf: LivyConf,
     zkManager: ZooKeeperManager)
   extends StateStore(livyConf) {
 
-  val ZK_KEY_PREFIX_CONF = Entry("livy.server.recovery.zk-state-store.key-prefix", "livy")
-  private val zkKeyPrefix = livyConf.get(ZK_KEY_PREFIX_CONF)
+  private val zkKeyPrefix = livyConf.get(LivyConf.RECOVERY_ZK_STATE_STORE_KEY_PREFIX)
   private def prefixKey(key: String) = s"/$zkKeyPrefix/$key"
 
   override def set(key: String, value: Object): Unit = {

--- a/server/src/main/scala/org/apache/livy/utils/LivyUncaughtException.java
+++ b/server/src/main/scala/org/apache/livy/utils/LivyUncaughtException.java
@@ -18,7 +18,7 @@
 package org.apache.livy.utils;
 
 public class LivyUncaughtException extends Exception {
-    LivyUncaughtException(String remoteStackTrace) {
-        super(remoteStackTrace);
-    }
+  public LivyUncaughtException(String remoteStackTrace) {
+    super(remoteStackTrace);
+  }
 }

--- a/server/src/main/scala/org/apache/livy/utils/LivyUncaughtException.java
+++ b/server/src/main/scala/org/apache/livy/utils/LivyUncaughtException.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.utils;
+
+public class LivyUncaughtException extends Exception {
+    LivyUncaughtException(String remoteStackTrace) {
+        super(remoteStackTrace);
+    }
+}

--- a/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
@@ -44,7 +44,7 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
       when(curatorClient.getUnhandledErrorListenable())
         .thenReturn(mock[Listenable[UnhandledErrorListener]])
       val zkManager = new ZooKeeperManager(conf, Some(curatorClient))
-      zkManager.startCuratorClient()
+      zkManager.start()
       val stateStore = new ZooKeeperStateStore(conf, zkManager)
       testBody(TestFixture(stateStore, curatorClient))
     }

--- a/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
@@ -34,7 +34,7 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
   describe("ZooKeeperStateStore") {
     case class TestFixture(stateStore: ZooKeeperStateStore, curatorClient: CuratorFramework)
     val conf = new LivyConf()
-    conf.set(LivyConf.RECOVERY_STATE_STORE_URL, "host")
+    conf.set(LivyConf.ZOOKEEPER_URL, "host")
     val key = "key"
     val prefixedKey = s"/livy/$key"
 
@@ -42,7 +42,9 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
       val curatorClient = mock[CuratorFramework]
       when(curatorClient.getUnhandledErrorListenable())
         .thenReturn(mock[Listenable[UnhandledErrorListener]])
-      val stateStore = new ZooKeeperStateStore(conf, Some(curatorClient))
+      ZooKeeperManager.reset()
+      ZooKeeperManager(conf, Some(curatorClient))
+      val stateStore = new ZooKeeperStateStore(conf)
       testBody(TestFixture(stateStore, curatorClient))
     }
 
@@ -57,11 +59,17 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
     it("should throw on bad config") {
       withMock { f =>
         val conf = new LivyConf()
-        intercept[IllegalArgumentException] { new ZooKeeperStateStore(conf) }
+        intercept[IllegalArgumentException] {
+          ZooKeeperManager.reset()
+          ZooKeeperManager(conf)
+        }
 
-        conf.set(LivyConf.RECOVERY_STATE_STORE_URL, "host")
-        conf.set(ZooKeeperStateStore.ZK_RETRY_CONF, "bad")
-        intercept[IllegalArgumentException] { new ZooKeeperStateStore(conf) }
+        conf.set(LivyConf.ZOOKEEPER_URL, "host")
+        conf.set(ZooKeeperManager.ZK_RETRY_CONF, "bad")
+        intercept[IllegalArgumentException] {
+          ZooKeeperManager.reset()
+          ZooKeeperManager(conf)
+        }
       }
     }
 
@@ -96,12 +104,12 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
     }
 
     it("get should retrieve retry policy configs") {
-      conf.set(org.apache.livy.server.recovery.ZooKeeperStateStore.ZK_RETRY_CONF, "11,77")
+      conf.set(org.apache.livy.server.recovery.ZooKeeperManager.ZK_RETRY_CONF, "11,77")
         withMock { f =>
         mockExistsBuilder(f.curatorClient, true)
 
-        f.stateStore.retryPolicy should not be null
-        f.stateStore.retryPolicy.getN shouldBe 11
+        ZooKeeperManager.get.retryPolicy should not be null
+        ZooKeeperManager.get.retryPolicy.getN shouldBe 11
       }
     }
 

--- a/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
@@ -44,6 +44,7 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
       when(curatorClient.getUnhandledErrorListenable())
         .thenReturn(mock[Listenable[UnhandledErrorListener]])
       val zkManager = new ZooKeeperManager(conf, Some(curatorClient))
+      zkManager.startCuratorClient()
       val stateStore = new ZooKeeperStateStore(conf, zkManager)
       testBody(TestFixture(stateStore, curatorClient))
     }

--- a/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
@@ -62,7 +62,7 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
         intercept[IllegalArgumentException] { new ZooKeeperManager(conf) }
 
         conf.set(LivyConf.RECOVERY_STATE_STORE_URL, "host")
-        conf.set(ZooKeeperManager.ZK_RETRY_CONF, "bad")
+        conf.set(LivyConf.RECOVERY_ZK_STATE_STORE_RETRY_POLICY, "bad")
         intercept[IllegalArgumentException] { new ZooKeeperManager(conf) }
       }
     }
@@ -98,7 +98,7 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
     }
 
     it("get should retrieve retry policy configs") {
-      conf.set(org.apache.livy.server.recovery.ZooKeeperManager.ZK_RETRY_CONF, "11,77")
+      conf.set(LivyConf.RECOVERY_ZK_STATE_STORE_RETRY_POLICY, "11,77")
         withMock { f =>
         mockExistsBuilder(f.curatorClient, true)
 

--- a/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/ZooKeeperStateStoreSpec.scala
@@ -62,7 +62,7 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
         intercept[IllegalArgumentException] { new ZooKeeperManager(conf) }
 
         conf.set(LivyConf.RECOVERY_STATE_STORE_URL, "host")
-        conf.set(LivyConf.RECOVERY_ZK_STATE_STORE_RETRY_POLICY, "bad")
+        conf.set(LivyConf.ZK_RETRY_POLICY, "bad")
         intercept[IllegalArgumentException] { new ZooKeeperManager(conf) }
       }
     }
@@ -98,7 +98,7 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
     }
 
     it("get should retrieve retry policy configs") {
-      conf.set(LivyConf.RECOVERY_ZK_STATE_STORE_RETRY_POLICY, "11,77")
+      conf.set(LivyConf.ZK_RETRY_POLICY, "11,77")
         withMock { f =>
         mockExistsBuilder(f.curatorClient, true)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the utilities of zookeeper mixed with ZooKeeperStateStore. To use the utility of zookeeper, the instance of ZooKeeperStateStore has to be created , which looks weird.

This PR aims to achieve two targets:

1. Extract the utilities of zookeeper from ZooKeeperStateStore to support such as distributed lock, service discovery and so on.

2. ZooKeeperManager which contains the utilities of zookeeper should be a single instance.

## How was this patch tested?

Existed UT and IT.
